### PR TITLE
ensure LiteralWidgets with the same content don't get re-rendered

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -13,6 +13,8 @@
 const debug = require('debug')('virtual-jade:compiler')
 const assert = require('assert')
 
+let literalWidgetCount = 0;
+
 module.exports = Compiler
 
 function Compiler(node, options) {
@@ -67,10 +69,10 @@ Compiler.prototype.compile = function () {
 
   if (this.hasLiteral) {
     js = `
-      function generateLiteralWidget(contents) {
-        function LiteralWidget(contents) {
+      function generateLiteralWidget(id, contents) {
+        function LiteralWidget(id, contents) {
           this.name = 'LiteralWidget'
-          this.id = contents
+          this.id = id
           this.contents = contents
         }
         LiteralWidget.prototype.type = 'Widget'
@@ -95,7 +97,7 @@ Compiler.prototype.compile = function () {
           host.appendChild(this.init())
           return h('text', host.innerHTML)
         }
-        return new LiteralWidget(contents)
+        return new LiteralWidget(id, contents)
       };
       ${js}
     `
@@ -144,7 +146,8 @@ Compiler.prototype.visitText = function (node) {
 Compiler.prototype.visitLiteral = function (node) {
   this.hasLiteral = true
   const escapedSource = node.str.replace(/'/g, '\\\'').replace(/\n/g, '')
-  return 'generateLiteralWidget(\'' + escapedSource + '\')'
+  const id = literalWidgetCount++
+  return 'generateLiteralWidget(' + id + ', \'' + escapedSource + '\')'
 }
 
 /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -13,7 +13,7 @@
 const debug = require('debug')('virtual-jade:compiler')
 const assert = require('assert')
 
-let literalWidgetCount = 0;
+let literalWidgetCount = 0
 
 module.exports = Compiler
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -69,6 +69,8 @@ Compiler.prototype.compile = function () {
     js = `
       function generateLiteralWidget(contents) {
         function LiteralWidget(contents) {
+          this.name = 'LiteralWidget'
+          this.id = contents
           this.contents = contents
         }
         LiteralWidget.prototype.type = 'Widget'
@@ -82,6 +84,9 @@ Compiler.prototype.compile = function () {
             root = wrapper
           }
           return root
+        }
+        LiteralWidget.prototype.update = function (previous, domNode) {
+          return domNode
         }
         // 'render' is called by the vdom-to-html module which is used in the unit tests
         LiteralWidget.prototype.render = function () {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -147,7 +147,7 @@ Compiler.prototype.visitLiteral = function (node) {
   this.hasLiteral = true
   const escapedSource = node.str.replace(/'/g, '\\\'').replace(/\n/g, '')
   const id = literalWidgetCount++
-  return 'generateLiteralWidget(' + id + ', \'' + escapedSource + '\')'
+  return `generateLiteralWidget(${id}, '${escapedSource}')`
 }
 
 /**


### PR DESCRIPTION
in order to not re-create an `LiteralWidget` on every patch, we need to give it a name and id: https://github.com/Matt-Esch/virtual-dom/blob/dcb8a14e96a5f78619510071fd39a5df52d381b7/vdom/update-widget.js#L7