### PR TITLE
Support normal attribute names in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create a template:
   each item in items
     .item(
       class={active: item.active}
-      dataset={id: item.id}
+      data-id=item.id
     )
       .item-title= item.title
       .item-description= item.description

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -186,6 +186,44 @@ Compiler.prototype.visitTag = function (tag) {
  * Also, `virtual-dom` handles properties differently.
  */
 
+// attribute -> property transformations
+const ATTRS_TO_PROPS = {
+  'class': 'className',
+  'for': 'htmlFor',
+  'http-equiv': 'httpEquiv',
+};
+const LOWERCASE_ATTRS = new Set([
+  'acceptCharset',
+  'accessKey',
+  'allowFullScreen',
+  'allowTransparency',
+  'cellPadding',
+  'cellSpacing',
+  'colSpan',
+  'contentEditable',
+  'contextMenu',
+  'crossOrigin',
+  'dateTime',
+  'formAction',
+  'formEncType',
+  'formMethod',
+  'formNoValidate',
+  'formTarget',
+  'frameBorder',
+  'marginHeight',
+  'marginWidth',
+  'maxLength',
+  'mediaGroup',
+  'noValidate',
+  'readOnly',
+  'rowSpan',
+  'tabIndex',
+  'useMap',
+]);
+for (const a of LOWERCASE_ATTRS) {
+  ATTRS_TO_PROPS[a.toLowerCase()] = a;
+}
+
 function dashedToCaps(s) {
   return s[1].toUpperCase()
 }
@@ -196,15 +234,13 @@ Compiler.prototype.visitAttributes = function (attrs) {
   const classExprs = []
   const dataset = {}
   for (const attr of attrs) {
-    const name = attr.name
+    const name = ATTRS_TO_PROPS[attr.name] || attr.name
     let val = attr.val
 
-    if (name === 'class' || name === 'className') {
+    if (name === 'className') {
       /**
        * We need to handle `class` separately because
        * it can be defined multiple times.
-       * Also, `virtual-dom` requires classes to be
-       * a `.className` property.
        */
       const isObj = !!val.match(/^\s*\{(.|[\r\n])+\}\s*$/)
       if (isObj) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -224,8 +224,9 @@ for (const a of LOWERCASE_ATTRS) {
   ATTRS_TO_PROPS[a.toLowerCase()] = a
 }
 
-function dashedToCaps(s) {
-  return s[1].toUpperCase()
+// convert this-type-of-string to thisTypeOfString
+function dashedToCamel(s) {
+  return s.replace(/-([a-z])/g, group => group[1].toUpperCase())
 }
 
 Compiler.prototype.visitAttributes = function (attrs) {
@@ -250,7 +251,7 @@ Compiler.prototype.visitAttributes = function (attrs) {
       classExprs.push(val)
     } else if (name.startsWith('data-')) {
       // strip data- and camelcase remainder for dataset
-      dataset[name.slice(5).replace(/-([a-z])/g, dashedToCaps)] = val
+      dataset[dashedToCamel(name.slice(5))] = val
     } else {
       props[name] = val
     }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -191,7 +191,7 @@ const ATTRS_TO_PROPS = {
   'class': 'className',
   'for': 'htmlFor',
   'http-equiv': 'httpEquiv',
-};
+}
 const LOWERCASE_ATTRS = new Set([
   'acceptCharset',
   'accessKey',
@@ -219,9 +219,9 @@ const LOWERCASE_ATTRS = new Set([
   'rowSpan',
   'tabIndex',
   'useMap',
-]);
+])
 for (const a of LOWERCASE_ATTRS) {
-  ATTRS_TO_PROPS[a.toLowerCase()] = a;
+  ATTRS_TO_PROPS[a.toLowerCase()] = a
 }
 
 function dashedToCaps(s) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -186,6 +186,10 @@ Compiler.prototype.visitTag = function (tag) {
  * Also, `virtual-dom` handles properties differently.
  */
 
+function dashedToCaps(s) {
+  return s[1].toUpperCase()
+}
+
 Compiler.prototype.visitAttributes = function (attrs) {
   // first, we need to format the attributes
   const props = Object.create(null)
@@ -210,7 +214,7 @@ Compiler.prototype.visitAttributes = function (attrs) {
       classExprs.push(val)
     } else if (name.startsWith('data-')) {
       // strip data- and camelcase remainder for dataset
-      dataset[name.slice(5).replace(/-([a-z])/g, s => s[1].toUpperCase())] = val
+      dataset[name.slice(5).replace(/-([a-z])/g, dashedToCaps)] = val
     } else {
       props[name] = val
     }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -190,34 +190,37 @@ Compiler.prototype.visitAttributes = function (attrs) {
   // first, we need to format the attributes
   const props = Object.create(null)
   const classExprs = []
+  const dataset = {}
   for (const attr of attrs) {
     const name = attr.name
     let val = attr.val
-    switch (name) {
+
+    if (name === 'class' || name === 'className') {
       /**
        * We need to handle `class` separately because
        * it can be defined multiple times.
        * Also, `virtual-dom` requires classes to be
        * a `.className` property.
        */
-
-      case 'class':
-      case 'className': {
-        const isObj = !!val.match(/^\s*\{(.|[\r\n])+\}\s*$/)
-        if (isObj) {
-          this.hasObjAttrs = true
-          val = `__objToAttrs(${val})`
-        }
-        classExprs.push(val)
-        break
+      const isObj = !!val.match(/^\s*\{(.|[\r\n])+\}\s*$/)
+      if (isObj) {
+        this.hasObjAttrs = true
+        val = `__objToAttrs(${val})`
       }
-      default:
-        props[name] = val
+      classExprs.push(val)
+    } else if (name.startsWith('data-')) {
+      // strip data- and camelcase remainder for dataset
+      dataset[name.slice(5).replace(/-([a-z])/g, s => s[1].toUpperCase())] = val
+    } else {
+      props[name] = val
     }
   }
   if (classExprs.length) {
     const classConcat = classExprs.map(e => `.concat(${e})`).join('')
     props.className = `[]${classConcat}.filter(Boolean).join(' ')`
+  }
+  if (Object.keys(dataset).length) {
+    props.dataset = JSON.stringify(dataset)
   }
 
   debug('properties: %o', props)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mocha-jsdom": "^1.1.0",
     "parse5-utils": "^1.3.1",
     "standardberry": "*",
-    "vdom-to-html": "^2.0.0",
+    "vdom-to-html": "tdumitrescu/vdom-to-html#dataset",
     "virtual-dom": "^2.0.1"
   },
   "scripts": {

--- a/test/fixtures/attributes.jade
+++ b/test/fixtures/attributes.jade
@@ -12,3 +12,5 @@ div#id.class1(
     }
     class=['mixedArray1', var2]
   )
+  input#special-attr(autocomplete="on")
+  label(for="special-attr") boo

--- a/test/fixtures/attributes.jade
+++ b/test/fixtures/attributes.jade
@@ -2,6 +2,7 @@ div#id.class1(
   class= ['1', '2', variable]
   required=true
   something=false
+  data-foo-id=42
 )
   div(class=[foo, bar] class=baz)
   div(class={obj1: true, obj2: variable === 'doge'})

--- a/test/fixtures/attributes.jade
+++ b/test/fixtures/attributes.jade
@@ -12,5 +12,5 @@ div#id.class1(
     }
     class=['mixedArray1', var2]
   )
-  input#special-attr(autocomplete="on")
+  input#special-attr(autocomplete="on" tabindex=5)
   label(for="special-attr") boo

--- a/test/test.js
+++ b/test/test.js
@@ -129,6 +129,11 @@ describe('Render', function () {
       assert(html.includes('mixedObj1'))
       assert(html.includes('doge'))
     })
+
+    it('should render data attributes',function () {
+      const html = renderFixture('attributes')
+      assert(html.includes('data-foo-id="42"'))
+    })
   })
 
   describe('case statements', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -130,9 +130,15 @@ describe('Render', function () {
       assert(html.includes('doge'))
     })
 
-    it('should render data attributes',function () {
+    it('should render data attributes', function () {
       const html = renderFixture('attributes')
       assert(html.includes('data-foo-id="42"'))
+    })
+
+    it('should convert attributes to correct property names', function () {
+      const html = renderFixture('attributes')
+      assert(html.includes('autocomplete="on"'))
+      assert(html.includes('for="special-attr"'))
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,7 @@ describe('Render', function () {
     it('should convert attributes to correct property names', function () {
       const html = renderFixture('attributes')
       assert(html.includes('autocomplete="on"'))
+      assert(html.includes('tabindex="5"'))
       assert(html.includes('for="special-attr"'))
     })
   })


### PR DESCRIPTION
so you can just write normal html attrs and don't have to resort to property names like `htmlFor` and `dataset`

temporarily using forked `vdom-to-html` for tests until I hear about https://github.com/nthtran/vdom-to-html/pull/23