### PR TITLE
[api,log,test] catch parsing/compilation errors with file/line detail

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,7 +11,15 @@
  */
 
 const debug = require('debug')('virtual-jade:compiler')
-const assert = require('assert')
+
+function assertWithDetailedError(node, assertion, message) {
+  if (!assertion) {
+    const err = new Error(message)
+    err.line = node.line
+    err.filename = node.filename
+    throw err
+  }
+}
 
 let literalWidgetCount = 0
 
@@ -41,21 +49,21 @@ Compiler.prototype.compile = function () {
         this.visitBlock(node)
         break
       case 'Code':
-        assert(!tagged, 'Code must exist before the tag.')
+        assertWithDetailedError(node, !tagged, 'Code must exist before the tag.')
         js += node.val + '\n'
         break
       case 'Mixin':
         this.visitMixin(node)
         break
       case 'Tag':
-        assert(!tagged, 'You can only have one top-level tag!')
+        assertWithDetailedError(node, !tagged, 'You can only have one top-level tag!')
         tagged = true
         js += 'return ' + this.visitTag(node)
         break
     }
   }
 
-  assert(tagged, 'Exactly a single root element is required!')
+  assertWithDetailedError(this.node, tagged, 'Exactly a single root element is required!')
 
   if (this.hasObjAttrs) {
     js = `
@@ -115,7 +123,8 @@ Compiler.prototype.compile = function () {
 
 Compiler.prototype.visit = function (node) {
   const method = 'visit' + node.type
-  assert(typeof this[method] === 'function',
+  assertWithDetailedError(node,
+    typeof this[method] === 'function',
     `Node type "${node.type}" is not implemented!`)
   return this[method](node)
 }
@@ -294,7 +303,7 @@ Compiler.prototype.visitBlock = function (block, wrap) {
     const node = nodes[i]
     switch (node.type) {
       case 'Code':
-        assert(!/^\s*else/.test(node.val), 'Hanging else statement!')
+        assertWithDetailedError(node, !/^\s*else/.test(node.val), 'Hanging else statement!')
 
         if (/^\s*if\s+/.test(node.val)) {
           // handle if statements

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Compiler = render.Compiler = require('./compiler')
 const lazy = require('lazyrequire')(require)
 const Parser = require('jade').Parser
+const rethrow = require('jade').runtime.rethrow
 const beautify = lazy('js-beautify')
 const addWith = require('with')
 
@@ -41,13 +42,24 @@ function render(str, options) {
   // parse
   const ParserCls = options.parser || Parser
   const parser = new ParserCls(str, options.filename)
-  const tokens = parser.parse()
+  let tokens
+  try {
+    tokens = parser.parse()
+  } catch (err) {
+    const context = parser.context()
+    rethrow(err, context.filename, context.lexer.lineno, context.input)
+  }
 
   // compile
   const compiler = new Compiler(tokens, options)
 
   // jade -> code
-  let out = render.runtime + compiler.compile()
+  let out = render.runtime
+  try {
+    out += compiler.compile()
+  } catch (err) {
+    rethrow(err, err.filename, err.line, parser.input)
+  }
 
   // add locals
   out = addWith('locals', out, render.globals)

--- a/test/fixtures/break-compiler.jade
+++ b/test/fixtures/break-compiler.jade
@@ -1,0 +1,2 @@
+div#id.class1
+div#id.class2

--- a/test/fixtures/break-parser.jade
+++ b/test/fixtures/break-parser.jade
@@ -1,0 +1,2 @@
+div#id.class1
+  div= space ghost

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,48 @@ function renderFixture(fixtureName, locals) {
 describe('Render', function () {
   jsdom();
 
+  it('should throw a parser error with filename and line number when rendering a broken template', function () {
+    const file = 'break-parser'
+    const filename = fixtureFilename(file)
+    const compile = function () {
+      render(fixture(file), {filename})
+    }
+    let threw = false
+
+    try {
+      compile()
+    } catch (err) {
+      threw = true
+      const filenameAndLineNo = new RegExp(filename.replace('/','\/') + ":2")
+      assert(err.path == filename, 'err.path should be the full path to the jade file')
+      assert(err.message.match(filenameAndLineNo), 'the error message should contain the full path and line number')
+      assert(err.message.match(/Unexpected identifier/), 'the error message should contain the error type')
+    } finally {
+      assert(threw, 'an error should be thrown')
+    }
+  })
+
+  it('should throw a compiler error with filename and line number when rendering a broken template', function () {
+    const file = 'break-compiler'
+    const filename = fixtureFilename(file)
+    const compile = function () {
+      render(fixture(file), {filename})
+    }
+    let threw = false
+
+    try {
+      compile()
+    } catch (err) {
+      threw = true
+      const filenameAndLineNo = new RegExp(filename.replace('/','\/') + ":2")
+      assert(err.path == filename, 'err.path (' + err.path + ') should be the full path to the jade file')
+      assert(err.message.match(filenameAndLineNo), 'the error message should contain the full path and line number')
+      assert(err.message.match(/You can only have one top-level tag!/), 'the error message should contain the error type')
+    } finally {
+      assert(threw, 'an error should be thrown')
+    }
+  })
+
   it('should render a template without options', function () {
     const compiled = render(fixture('attributes'))
     assert(compiled.includes('class1'))
@@ -229,6 +271,11 @@ describe('Render', function () {
   })
 })
 
+
+function fixtureFilename(name) {
+  return path.resolve(__dirname, 'fixtures/' + name + '.jade')
+}
+
 function fixture(name) {
-  return fs.readFileSync(path.resolve(__dirname, 'fixtures/' + name + '.jade'), 'utf8')
+  return fs.readFileSync(fixtureFilename(name), 'utf8')
 }


### PR DESCRIPTION
This feature adds detailed errors when parsing/compiling a .jade template.  It's based on [the original parse() logic from Jade 1.x](https://github.com/pugjs/pug/blob/v1.x.x/lib/index.js#L102).

For the test case committed, the detailed error looks like:
```jade
/home/charles/source/virtual-jade/test/fixtures/attributes-broken.jade:2
    1| div#id.class1
  > 2|   div= space ghost
    3| 

Unexpected identifier
```

This way when the error is bubbled up to virtual-jade-loader or gulp-pug-hyperscript, we can see the filename and line number.

Happy Friday!