### PR TITLE
Fix each-iteration in snabbdom

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,52 +11,22 @@ module.exports = {
   },
 
   rules: {
-    'arrow-parens': [
-      'error', 'as-needed',
-    ],
-    'camelcase': [
-      'error', {'properties': 'always'},
-    ],
-    'comma-dangle': [
-      'error', 'always-multiline',
-    ],
-    'comma-spacing': [
-      'error', {'before': false, 'after': true},
-    ],
-    'eol-last':
-      'error',
-    'eqeqeq':
-      'error',
-    'indent': [
-      'error', 2, {SwitchCase: 1},
-    ],
-    'linebreak-style': [
-      'error', 'unix',
-    ],
-    'multiline-ternary': [
-      'error', 'never',
-    ],
-    'no-console': [
-      'warn', {allow: ['info', 'warn', 'error']},
-    ],
-    'no-debugger':
-      'warn',
-    'no-unused-expressions':
-      'error',
-    'no-use-before-define': [
-      'error', {classes: false},
-    ],
-    'quotes': [
-      'error', 'backtick',
-    ],
-    'semi': [
-      'error', 'always',
-    ],
-    'space-before-blocks': [
-      'error', 'always',
-    ],
-    'space-before-function-paren': [
-      'error', 'never',
-    ],
+    'arrow-parens':                ['error', 'as-needed'                       ],
+    'camelcase':                   ['error', {'properties': 'always'}          ],
+    'comma-dangle':                ['error', 'always-multiline'                ],
+    'comma-spacing':               ['error', {'before': false, 'after': true}  ],
+    'eol-last':                    ['error',                                   ],
+    'eqeqeq':                      ['error',                                   ],
+    'indent':                      ['error', 2, {SwitchCase: 1}                ],
+    'linebreak-style':             ['error', 'unix'                            ],
+    'multiline-ternary':           ['error', 'never'                           ],
+    'no-console':                  ['warn',  {allow: ['info', 'warn', 'error']}],
+    'no-debugger':                 ['warn',                                    ],
+    'no-unused-expressions':       ['error',                                   ],
+    'no-use-before-define':        ['error', {classes: false}                  ],
+    'quotes':                      ['error', 'backtick'                        ],
+    'semi':                        ['error', 'always'                          ],
+    'space-before-blocks':         ['error', 'always'                          ],
+    'space-before-function-paren': ['error', 'never'                           ],
   },
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -192,17 +192,7 @@ Compiler.prototype.visitTag = function(tag) {
   } else {
     let buf2 = this.visitBlock(tag.block);
     if (buf2) {
-      // children must always be an array
-      // https://github.com/Matt-Esch/virtual-dom/blob/master/docs/vnode.md#arguments
-      // TODO: test
-      buf2 = buf2.trim();
-      if (
-        !(buf2.startsWith(`[`) && buf2.endsWith(`]`)) &&
-        !buf2.startsWith(`(function() {var __jade_nodes`)
-      ) {
-        buf2 = `[${buf2}]`;
-      }
-      buf += `, ${buf2}.filter(Boolean)`;
+      buf += `, ${buf2.trim()}.filter(Boolean)`;
     }
   }
   buf += `)`;
@@ -315,10 +305,6 @@ Compiler.prototype.visitBlock = function(block) {
 
   let buf = ``;
 
-  // if there are non-control-flow code nodes, then construct array
-  // by pushing one value at a time in output func
-  const arrayPushMode = !!nodes.filter(n => n.type === `Code` || n.type === `Each`).length;
-
   for (let i = 0; i < nodes.length; i++) {
     let curNodeBuf = ``;
     const node = nodes[i];
@@ -378,22 +364,13 @@ Compiler.prototype.visitBlock = function(block) {
       default: {
         curNodeBuf = this.visit(node);
         if (curNodeBuf) {
-          buf += arrayPushMode ? `__jade_nodes = __jade_nodes.concat(${curNodeBuf});` : `${curNodeBuf},`;
+          buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
         }
       }
     }
   }
 
-  if (!buf) return ``;
-
-  if (arrayPushMode) {
-    return `(function() {var __jade_nodes = [];${buf};return __jade_nodes}).call(this)`;
-  }
-
-  // single value, so remove the trailing comma
-  if (length === 1) return buf.replace(/\,$/, ``);
-  // array of values
-  return `[${buf}]`;
+  return buf ? `(function() {var __jade_nodes = [];${buf};return __jade_nodes}).call(this)` : ``;
 };
 
 /**
@@ -430,12 +407,18 @@ Compiler.prototype.visitCase = function(code) {
 
 /**
  * Handle each statements
+ * uses Array.concat() with result of each iteration to ensure flattening
  */
 
 Compiler.prototype.visitEach = function(code) {
-  return `(${code.obj}).map(function (${code.val}, ${code.key}) {
-    return ${this.visitBlock(code.block)}
-  })`;
+  return `(function(__list) {
+    var __each_nodes = [];
+    for (var ${code.key} = 0; ${code.key} < __list.length; ${code.key}++) {
+      var ${code.val} = __list[${code.key}];
+      __each_nodes = __each_nodes.concat(${this.visitBlock(code.block)});
+    }
+    return __each_nodes;
+  })(${code.obj})`;
 };
 
 /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -317,7 +317,7 @@ Compiler.prototype.visitBlock = function(block) {
 
   // if there are non-control-flow code nodes, then construct array
   // by pushing one value at a time in output func
-  const arrayPushMode = !!nodes.filter(n => n.type === `Code`).length;
+  const arrayPushMode = !!nodes.filter(n => n.type === `Code` || n.type === `Each`).length;
 
   for (let i = 0; i < nodes.length; i++) {
     let curNodeBuf = ``;
@@ -370,6 +370,10 @@ Compiler.prototype.visitBlock = function(block) {
       case `Comment`:
       case `BlockComment`:
         buf += this.visitComment(node);
+        break;
+      case `Each`:
+        curNodeBuf = this.visitEach(node);
+        buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
         break;
       default: {
         curNodeBuf = this.visit(node);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "eslint": "3.10.2",
+    "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "js-beautify": "^1.5.5",
     "jsdom": "^9.2.1",

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -30,48 +30,48 @@ function testCompilation(fixtureName, options) {
 
 
 describe(`Compiler`, function() {
-  it(`should compile functions as properties`, function() {
+  it(`compiles functions as properties`, function() {
     testCompilation(`inline-function`);
   });
 
-  it(`should throw if there is not exactly 1 tag`, function() {
+  it(`throws if there is not exactly 1 tag`, function() {
     expect(testCompilation).withArgs(`root-if`).to.throwException();
     expect(testCompilation).withArgs(`empty`).to.throwException();
     expect(testCompilation).withArgs(`multiple-tags`).to.throwException();
   });
 
-  it(`should compile the boilerplate`, function() {
+  it(`compiles the boilerplate`, function() {
     let js = testCompilation(`boilerplate`);
     let root = eval(`${VDOM_RUNTIME}(function(){${js}})()`);
     let html = toHTML(root);
     parse5.parse(html, true);
   });
 
-  it(`should compile attributes`, function() {
+  it(`compiles attributes`, function() {
     let js = testCompilation(`attributes`);
     expect(js).not.to.match(/\bclass\b/);
     expect(js.match(/"className"/g)).to.have.length(4);
   });
 
-  it(`should compile data attributes to dataset`, function() {
+  it(`compiles data attributes to dataset`, function() {
     let js = testCompilation(`attributes`);
     expect(js).not.to.match(/\bdata-foo\b/);
     expect(js).to.match(/\bdataset\b/);
   });
 
-  it(`should optionally not compile data attributes to dataset`, function() {
+  it(`optionally does not compile data attributes to dataset`, function() {
     let js = testCompilation(`attributes`, {marshalDataset: false});
     expect(js).not.to.match(/\bdataset\b/);
     expect(js).to.match(/\bdata-foo\b/);
   });
 
-  it(`should handle basic string interpolation`, function() {
+  it(`handles basic string interpolation`, function() {
     let js = testCompilation(`interpolation`);
     expect(js).to.contain(`+ (x + 5) +`);
     expect(js).to.contain(`+ (x - 2) +`);
   });
 
-  it(`should compile if statements`, function() {
+  it(`compiles if statements`, function() {
     let js = testCompilation(`if`);
     expect(js).not.to.contain(`undefined(`);
     let root = eval(`${VDOM_RUNTIME}(function(){${js}})()`);
@@ -84,60 +84,60 @@ describe(`Compiler`, function() {
     expect(html).not.to.contain(`a3`);
   });
 
-  it(`should compile case statements`, function() {
+  it(`compiles case statements`, function() {
     testCompilation(`case`);
   });
 
-  it(`should compile top-level JS`, function() {
+  it(`compiles top-level JS`, function() {
     let js = testCompilation(`top-level-code`);
     expect(js).to.contain(`var a = 1\n`);
     expect(js).to.contain(`var b = 2\n`);
   });
 
-  it(`should compile JS in blocks`, function() {
+  it(`compiles JS in blocks`, function() {
     let js = testCompilation(`code`);
     expect(js).to.contain(`foo = ['bar']`);
   });
 
-  it(`should compile each`, function() {
+  it(`compiles each`, function() {
     testCompilation(`each`);
   });
 
-  it(`should compile each, index`, function() {
+  it(`compiles each, index`, function() {
     let js = testCompilation(`each-index`);
     expect(js).to.contain(`anIndex`);
   });
 
-  it(`should compile each w/ expressions`, function() {
+  it(`compiles each w/ expressions`, function() {
     testCompilation(`each-expression`);
   });
 
-  it(`should compile a while loop`, function() {
+  it(`compiles a while loop`, function() {
     testCompilation(`while`);
   });
 
-  it(`should compile mixins without arguments`, function() {
+  it(`compiles mixins without arguments`, function() {
     let js = testCompilation(`mixin`);
     expect(js).to.contain(`jade_mixins['item'].call(this)`);
   });
 
-  it(`should compile mixins with arguments`, function() {
+  it(`compiles mixins with arguments`, function() {
     let js = testCompilation(`mixin-args`);
     expect(js).to.contain(`jade_mixins['item'].call(this, 5)`);
   });
 
-  it(`should compile mixins with rest arguments`, function() {
+  it(`compiles mixins with rest arguments`, function() {
     let js = testCompilation(`mixin-rest`);
     expect(js).to.contain(`function(x)`);
     expect(js).to.contain(`jade_mixins['item'].call(this, 5, 'a', 'b')`);
   });
 
-  it(`should compile mixins with blocks`, function() {
+  it(`compiles mixins with blocks`, function() {
     let js = testCompilation(`mixin-block`);
     expect(js).to.contain(`jade_mixins['item'].call({block: function()`);
   });
 
-  it(`should compile mixins with attributes`, function() {
+  it(`compiles mixins with attributes`, function() {
     let js = testCompilation(`mixin-attrs`);
     expect(js).to.contain(`jade_mixins['item'].call({attributes: {`);
   });

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const assert = require(`assert`);
 const expect = require(`expect.js`);
 const fs = require(`fs`);
 const parse5 = require(`parse5-utils`);
@@ -50,39 +49,39 @@ describe(`Compiler`, function() {
 
   it(`should compile attributes`, function() {
     let js = testCompilation(`attributes`);
-    assert(!js.match(/\bclass\b/), `\`class\` found somewhere!`);
-    assert.equal(js.match(/"className"/g).length, 4, `Incorrect number of class properties set.`);
+    expect(js).not.to.match(/\bclass\b/);
+    expect(js.match(/"className"/g)).to.have.length(4);
   });
 
   it(`should compile data attributes to dataset`, function() {
     let js = testCompilation(`attributes`);
-    assert(!js.match(/\bdata-foo\b/), `\`data-foo\` found somewhere!`);
-    assert(js.match(/\bdataset\b/), `\`dataset\` not found!`);
+    expect(js).not.to.match(/\bdata-foo\b/);
+    expect(js).to.match(/\bdataset\b/);
   });
 
   it(`should optionally not compile data attributes to dataset`, function() {
     let js = testCompilation(`attributes`, {marshalDataset: false});
-    assert(!js.match(/\bdataset\b/), `\`dataset\` found somewhere!`);
-    assert(js.match(/\bdata-foo\b/), `\`data-foo\` not found!`);
+    expect(js).not.to.match(/\bdataset\b/);
+    expect(js).to.match(/\bdata-foo\b/);
   });
 
   it(`should handle basic string interpolation`, function() {
     let js = testCompilation(`interpolation`);
-    assert(~js.indexOf(`+ (x + 5) +`));
-    assert(~js.indexOf(`+ (x - 2) +`));
+    expect(js).to.contain(`+ (x + 5) +`);
+    expect(js).to.contain(`+ (x - 2) +`);
   });
 
   it(`should compile if statements`, function() {
     let js = testCompilation(`if`);
-    assert(!~js.indexOf(`undefined(`));
+    expect(js).not.to.contain(`undefined(`);
     let root = eval(`${VDOM_RUNTIME}(function(){${js}})()`);
     let html = toHTML(root);
     parse5.parse(html, true);
-    assert(~html.indexOf(`<span></span><span></span>`));
-    assert(!~html.indexOf(`<em>`));
-    assert(~html.indexOf(`a1`));
-    assert(!~html.indexOf(`a2`));
-    assert(!~html.indexOf(`a3`));
+    expect(html).to.contain(`<span></span><span></span>`);
+    expect(html).not.to.contain(`<em>`);
+    expect(html).to.contain(`a1`);
+    expect(html).not.to.contain(`a2`);
+    expect(html).not.to.contain(`a3`);
   });
 
   it(`should compile case statements`, function() {
@@ -91,13 +90,13 @@ describe(`Compiler`, function() {
 
   it(`should compile top-level JS`, function() {
     let js = testCompilation(`top-level-code`);
-    assert(~js.indexOf(`var a = 1\n`));
-    assert(~js.indexOf(`var b = 2\n`));
+    expect(js).to.contain(`var a = 1\n`);
+    expect(js).to.contain(`var b = 2\n`);
   });
 
   it(`should compile JS in blocks`, function() {
     let js = testCompilation(`code`);
-    assert(~js.indexOf(`foo = ['bar']`));
+    expect(js).to.contain(`foo = ['bar']`);
   });
 
   it(`should compile each`, function() {
@@ -106,7 +105,7 @@ describe(`Compiler`, function() {
 
   it(`should compile each, index`, function() {
     let js = testCompilation(`each-index`);
-    assert(~js.indexOf(`anIndex`));
+    expect(js).to.contain(`anIndex`);
   });
 
   it(`should compile each w/ expressions`, function() {
@@ -119,27 +118,27 @@ describe(`Compiler`, function() {
 
   it(`should compile mixins without arguments`, function() {
     let js = testCompilation(`mixin`);
-    assert(~js.indexOf(`jade_mixins['item'].call(this)`));
+    expect(js).to.contain(`jade_mixins['item'].call(this)`);
   });
 
   it(`should compile mixins with arguments`, function() {
     let js = testCompilation(`mixin-args`);
-    assert(~js.indexOf(`jade_mixins['item'].call(this, 5)`));
+    expect(js).to.contain(`jade_mixins['item'].call(this, 5)`);
   });
 
   it(`should compile mixins with rest arguments`, function() {
     let js = testCompilation(`mixin-rest`);
-    assert(~js.indexOf(`function(x)`));
-    assert(~js.indexOf(`jade_mixins['item'].call(this, 5, 'a', 'b')`));
+    expect(js).to.contain(`function(x)`);
+    expect(js).to.contain(`jade_mixins['item'].call(this, 5, 'a', 'b')`);
   });
 
   it(`should compile mixins with blocks`, function() {
     let js = testCompilation(`mixin-block`);
-    assert(~js.indexOf(`jade_mixins['item'].call({block: function()`));
+    expect(js).to.contain(`jade_mixins['item'].call({block: function()`);
   });
 
   it(`should compile mixins with attributes`, function() {
     let js = testCompilation(`mixin-attrs`);
-    assert(~js.indexOf(`jade_mixins['item'].call({attributes: {`));
+    expect(js).to.contain(`jade_mixins['item'].call({attributes: {`);
   });
 });

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -2,12 +2,13 @@
 
 'use strict';
 
-const toHTML = require(`vdom-to-html`);
+const assert = require(`assert`);
+const expect = require(`expect.js`);
+const fs = require(`fs`);
 const parse5 = require(`parse5-utils`);
 const Parser = require(`jade`).Parser;
-const assert = require(`assert`);
 const path = require(`path`);
-const fs = require(`fs`);
+const toHTML = require(`vdom-to-html`);
 
 const Compiler = require(`../lib/compiler`);
 const VDOM_RUNTIME = require(`../lib/config`).VDOM_CONFIG[`virtual-dom`].runtime;
@@ -35,17 +36,9 @@ describe(`Compiler`, function() {
   });
 
   it(`should throw if there is not exactly 1 tag`, function() {
-    assert.throws(function() {
-      testCompilation(`root-if`);
-    });
-
-    assert.throws(function() {
-      testCompilation(`empty`);
-    });
-
-    assert.throws(function() {
-      testCompilation(`multiple-tags`);
-    });
+    expect(testCompilation).withArgs(`root-if`).to.throwException();
+    expect(testCompilation).withArgs(`empty`).to.throwException();
+    expect(testCompilation).withArgs(`multiple-tags`).to.throwException();
   });
 
   it(`should compile the boilerplate`, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -138,12 +138,12 @@ for (let vdom of VDOM_LIBS) {
         },
       });
 
-      assert(~html.indexOf(`item active`));
-      assert(~html.indexOf(`class="title"`));
-      assert(~html.indexOf(`<h3`));
-      assert(~html.indexOf(`</h3>`));
-      assert(~html.indexOf(`some title`));
-      assert(~html.indexOf(`some description`));
+      expect(html).to.contain(`item active`);
+      expect(html).to.contain(`class="title"`);
+      expect(html).to.contain(`<h3`);
+      expect(html).to.contain(`</h3>`);
+      expect(html).to.contain(`some title`);
+      expect(html).to.contain(`some description`);
     });
 
     it(`should beautify when option is set`, function() {
@@ -302,15 +302,15 @@ for (let vdom of VDOM_LIBS) {
       });
 
       it(`should run unbuffered code correctly`, function() {
-        assert(~html.indexOf(`<div class="example bar">`));
+        expect(html).to.contain(`<div class="example bar">`);
       });
 
       it(`should use locals when evaluating`, function() {
         html = renderFixture(`code`, {x: 0});
-        assert(~html.indexOf(`<div class="baz">`));
+        expect(html).to.contain(`<div class="baz">`);
 
         html = renderFixture(`code`, {x: -1});
-        assert(!~html.indexOf(`<div class="baz">`));
+        expect(html).not.to.contain(`<div class="baz">`);
       });
 
       it(`should output inline buffered code`, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const assert = require(`assert`);
 const debug = require(`debug`)(`test`);
 const expect = require(`expect.js`);
 const fs = require(`fs`);
@@ -122,8 +121,8 @@ for (let vdom of VDOM_LIBS) {
     it(`should beautify when option is set`, function() {
       const fn = render(fixture(`item`), {pretty: true});
       const lines = fn.split(`\n`);
-      assert(lines.length > 15);
-      assert(lines[lines.length - 1].trim() === `}`);
+      expect(lines.length).to.be.greaterThan(15);
+      expect(lines[lines.length - 1].trim()).to.be(`}`);
     });
 
     it(`should insert dynamic tag names`, function() {
@@ -135,7 +134,7 @@ for (let vdom of VDOM_LIBS) {
 
     it(`renders a simple template`, function() {
       const html = renderFixture(`simple`);
-      assert(html === `<div>This is text</div>`);
+      expect(html).to.be(`<div>This is text</div>`);
     });
 
     it(`translates basic class notation`, function() {
@@ -312,7 +311,7 @@ describe(`Render`, function() {
       const htmlEntities = function(str) {
         return String(str).replace(/&/g, `&amp;`).replace(/</g, `&lt;`).replace(/>/g, `&gt;`).replace(/"/g, `&quot;`);
       };
-      const expectedContents =
+      expect(html).to.be(
         `<div class="raw">` +
           `<div class="single-root">` +
             `<text>` + htmlEntities(singleRootImport) + `</text>` +
@@ -320,8 +319,8 @@ describe(`Render`, function() {
           `<div class="multi-root">` +
             `<text>` + htmlEntities(`<div>` + multiRootImport + `</div>`) + `</text>` +
           `</div>` +
-        `</div>`;
-      assert(html === expectedContents);
+        `</div>`
+      );
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -48,14 +48,14 @@ function fixtureToHTML(fixtureName, locals, options) {
 }
 
 describe(`configuration`, function() {
-  it(`should throw when an invalid vdom config is supplied`, function() {
+  it(`throws when an invalid vdom config is supplied`, function() {
     expect(render).withArgs(fixture(`simple`), {
       filename: fixtureFilename(`simple`),
       vdom: `foobar`,
     }).to.throwException(`No virtual-jade config found for vdom type: foobar`);
   });
 
-  it(`should throw a parser error with filename and line number when rendering a broken template`, function() {
+  it(`throws a parser error with filename and line number when rendering a broken template`, function() {
     const file = `break-parser`;
     const filename = fixtureFilename(file);
 
@@ -67,7 +67,7 @@ describe(`configuration`, function() {
     });
   });
 
-  it(`should throw a compiler error with filename and line number when rendering a broken template`, function() {
+  it(`throws a compiler error with filename and line number when rendering a broken template`, function() {
     const file = `break-compiler`;
     const filename = fixtureFilename(file);
     expect(render).withArgs(fixture(file), {filename}).to.throwException(function(err) {
@@ -78,7 +78,7 @@ describe(`configuration`, function() {
     });
   });
 
-  it(`should render a template without options`, function() {
+  it(`renders a template without options`, function() {
     const compiled = render(fixture(`attributes`));
     expect(compiled).to.contain(`class1`);
     expect(compiled).to.contain(`foo`);
@@ -100,7 +100,7 @@ for (let vdom of VDOM_LIBS) {
   };
 
   describe(`rendering with ${vdom}`, function() {
-    it(`should render a template`, function() {
+    it(`renders a template`, function() {
       const html = renderFixture(`item`, {
         item: {
           id: `1234`,
@@ -118,14 +118,14 @@ for (let vdom of VDOM_LIBS) {
       expect(html).to.contain(`some description`);
     });
 
-    it(`should beautify when option is set`, function() {
+    it(`beautifies when option is set`, function() {
       const fn = render(fixture(`item`), {pretty: true});
       const lines = fn.split(`\n`);
       expect(lines.length).to.be.greaterThan(15);
       expect(lines[lines.length - 1].trim()).to.be(`}`);
     });
 
-    it(`should insert dynamic tag names`, function() {
+    it(`inserts dynamic tag names`, function() {
       let html = renderFixture(`dynamic-tag`, {myTag: `input`});
       expect(html).to.contain(`<input class="llamas">`);
       html = renderFixture(`dynamic-tag`, {myTag: `textarea`});
@@ -144,32 +144,32 @@ for (let vdom of VDOM_LIBS) {
     });
 
     describe(`iteration`, function() {
-      it(`should run "each" loops correctly`, function() {
+      it(`runs "each" loops correctly`, function() {
         const html = renderFixture(`each-expression`, {values: [`foo`, `bar`]});
         expect(html).to.contain(`<li>foo</li><li>bar</li>`);
       });
 
-      it(`should run "while" loops correctly`, function() {
+      it(`runs "while" loops correctly`, function() {
         const html = renderFixture(`while`);
         expect(html.match(/<div class=\"item\">/g)).to.have.length(5);
       });
     });
 
     describe(`multiple files`, function() {
-      it(`should insert included files`, function() {
+      it(`inserts included files`, function() {
         const html = renderFixture(`include`);
         expect(html).to.contain(`<p>Hello</p>`);
         expect(html).to.contain(`<div class="included-content">llamas!!!</div>`);
         expect(html).to.contain(`<p>world</p>`);
       });
 
-      it(`should make included mixins available`, function() {
+      it(`makes included mixins available`, function() {
         const html = renderFixture(`include-with-mixin`);
         expect(html).to.contain(`<div class="foo">`);
         expect(html).to.contain(`<div class="hello">insert me</div>`);
       });
 
-      it(`should insert extended files`, function() {
+      it(`inserts extended files`, function() {
         const html = renderFixture(`extends`);
         expect(html).to.contain(`<div class="foo">`);
         expect(html).to.contain(`capybara`);
@@ -178,20 +178,20 @@ for (let vdom of VDOM_LIBS) {
     });
 
     describe(`attributes`, function() {
-      it(`should add arbitrary attributes`, function() {
+      it(`adds arbitrary attributes`, function() {
         const html = renderFixture(`attributes`);
         expect(html).to.contain(`required`);
         expect(!html.includes(`something`) || html.includes(`something="false"`)).to.be.ok();
       });
 
-      it(`should add class attributes in array notation`, function() {
+      it(`adds class attributes in array notation`, function() {
         let html = renderFixture(`attributes`);
         expect(html).to.contain(`1 2`);
         html = renderFixture(`attributes`, {variable: `meow`});
         expect(html).to.contain(`1 2 meow`);
       });
 
-      it(`should add class attributes in object notation`, function() {
+      it(`adds class attributes in object notation`, function() {
         let html = renderFixture(`attributes`);
         expect(html).to.contain(`obj1`);
         expect(html).not.to.contain(`obj2`);
@@ -201,7 +201,7 @@ for (let vdom of VDOM_LIBS) {
         expect(html).to.contain(`obj2`);
       });
 
-      it(`should combine class attributes in different notations gracefully`, function() {
+      it(`combines class attributes in different notations gracefully`, function() {
         let html = renderFixture(`attributes`);
         expect(html).to.contain(`mixed`);
         expect(html).to.contain(`mixedArray1`);
@@ -214,13 +214,13 @@ for (let vdom of VDOM_LIBS) {
         expect(html).to.contain(`doge`);
       });
 
-      it(`should render data attributes`, function() {
+      it(`renders data attributes`, function() {
         const html = renderFixture(`attributes`, {variable: `capybara`});
         expect(html).to.contain(`data-foo-id="42"`);
         expect(html).to.contain(`data-var="capybara"`);
       });
 
-      it(`should convert attributes to correct property names`, function() {
+      it(`converts attributes to correct property names`, function() {
         const html = renderFixture(`attributes`);
         expect(html).to.contain(`autocomplete="on"`);
         expect(html).to.contain(`tabindex="5"`);
@@ -229,37 +229,37 @@ for (let vdom of VDOM_LIBS) {
     });
 
     describe(`case statements`, function() {
-      it(`should not execute any cases when none match`, function() {
+      it(`does not execute any cases when none match`, function() {
         const html = renderFixture(`case`);
         expect(html).not.to.contain(`foo`);
         expect(html).not.to.contain(`bar`);
       });
 
-      it(`should execute default when no others match`, function() {
+      it(`executes default when no others match`, function() {
         const html = renderFixture(`case`);
         expect(html).to.contain(`llama`);
       });
 
-      it(`should execute only one match`, function() {
+      it(`executes only one match`, function() {
         const html = renderFixture(`case`, {variable: 1});
         expect(html).to.contain(`span`);
         expect(html).not.to.contain(`input`);
         expect(html).not.to.contain(`textarea`);
       });
 
-      it(`should fall through from the first case in a chain`, function() {
+      it(`falls through from the first case in a chain`, function() {
         const html = renderFixture(`case`, {variable2: `d`});
         expect(html).to.contain(`bar`);
         expect(html).not.to.contain(`foo`);
       });
 
-      it(`should fall through from the middle case in a chain`, function() {
+      it(`falls through from the middle case in a chain`, function() {
         const html = renderFixture(`case`, {variable2: `e`});
         expect(html).to.contain(`bar`);
         expect(html).not.to.contain(`foo`);
       });
 
-      it(`should fall through from the last case in a chain`, function() {
+      it(`falls through from the last case in a chain`, function() {
         const html = renderFixture(`case`, {variable2: `f`});
         expect(html).to.contain(`bar`);
         expect(html).not.to.contain(`foo`);
@@ -273,11 +273,11 @@ for (let vdom of VDOM_LIBS) {
         html = renderFixture(`code`);
       });
 
-      it(`should run unbuffered code correctly`, function() {
+      it(`runs unbuffered code correctly`, function() {
         expect(html).to.contain(`<div class="example bar">`);
       });
 
-      it(`should use locals when evaluating`, function() {
+      it(`uses locals when evaluating`, function() {
         html = renderFixture(`code`, {x: 0});
         expect(html).to.contain(`<div class="baz">`);
 
@@ -285,15 +285,15 @@ for (let vdom of VDOM_LIBS) {
         expect(html).not.to.contain(`<div class="baz">`);
       });
 
-      it(`should output inline buffered code`, function() {
+      it(`outputs inline buffered code`, function() {
         expect(html).to.contain(`<div class="inline-script"><div class="raw-inline">within another div`);
       });
 
-      it(`should output standalone buffered code`, function() {
+      it(`outputs standalone buffered code`, function() {
         expect(html).to.contain(`<div class="raw-buffered">raw so raw`);
       });
 
-      it(`should not output unbuffered code`, function() {
+      it(`does not output unbuffered code`, function() {
         expect(html).not.to.contain(`should not be output`);
       });
     });
@@ -304,7 +304,7 @@ describe(`Render`, function() {
   jsdom();
 
   describe(`multiple files`, function() {
-    it(`should insert included literal (non-jade) files`, function() {
+    it(`inserts included literal (non-jade) files`, function() {
       const html = fixtureToHTML(`literal-import`);
       const singleRootImport = `<div class="test">test</div>`;
       const multiRootImport = `<div>child 1</div><div>child 2</div>`;

--- a/test/test.js
+++ b/test/test.js
@@ -170,7 +170,7 @@ for (let vdom of VDOM_LIBS) {
 
     describe(`iteration`, function() {
       it(`should run "each" loops correctly`, function() {
-        const html = renderFixture(`each-expression`, {values: ['foo', 'bar']});
+        const html = renderFixture(`each-expression`, {values: [`foo`, `bar`]});
         assert(html.includes(`<li>foo</li><li>bar</li>`));
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const assert = require(`assert`);
+const debug = require(`debug`)(`test`);
 const fs = require(`fs`);
 const jsdom = require(`mocha-jsdom`);
 const parse5 = require(`parse5-utils`);
@@ -34,6 +35,8 @@ function fixtureToHTML(fixtureName, locals, options) {
   }
 
   const compiled = render(fixture(fixtureName), options);
+  debug(compiled);
+
   const fn = eval(`(${compiled})`);
   const root = fn.call({class: `asdf`}, locals);
   const toHTML = snabb ? snabbdomToHTML : vdomToHTML;

--- a/test/test.js
+++ b/test/test.js
@@ -108,9 +108,9 @@ describe(`configuration`, function() {
 
   it(`should render a template without options`, function() {
     const compiled = render(fixture(`attributes`));
-    assert(compiled.includes(`class1`));
-    assert(compiled.includes(`foo`));
-    assert(compiled.includes(`doge`));
+    expect(compiled).to.contain(`class1`);
+    expect(compiled).to.contain(`foo`);
+    expect(compiled).to.contain(`doge`);
   });
 });
 
@@ -155,9 +155,9 @@ for (let vdom of VDOM_LIBS) {
 
     it(`should insert dynamic tag names`, function() {
       let html = renderFixture(`dynamic-tag`, {myTag: `input`});
-      assert(html.includes(`<input class="llamas">`));
+      expect(html).to.contain(`<input class="llamas">`);
       html = renderFixture(`dynamic-tag`, {myTag: `textarea`});
-      assert(html.includes(`<textarea class="llamas">`));
+      expect(html).to.contain(`<textarea class="llamas">`);
     });
 
     it(`renders a simple template`, function() {
@@ -167,8 +167,8 @@ for (let vdom of VDOM_LIBS) {
 
     it(`translates basic class notation`, function() {
       const html = renderFixture(`class`);
-      assert(html.includes(`div class="foo"`));
-      assert(html.includes(`div class="baz llamas"`));
+      expect(html).to.contain(`div class="foo"`);
+      expect(html).to.contain(`div class="baz llamas"`);
     });
 
     describe(`iteration`, function() {
@@ -186,111 +186,111 @@ for (let vdom of VDOM_LIBS) {
     describe(`multiple files`, function() {
       it(`should insert included files`, function() {
         const html = renderFixture(`include`);
-        assert(html.includes(`<p>Hello</p>`));
-        assert(html.includes(`<div class="included-content">llamas!!!</div>`));
-        assert(html.includes(`<p>world</p>`));
+        expect(html).to.contain(`<p>Hello</p>`);
+        expect(html).to.contain(`<div class="included-content">llamas!!!</div>`);
+        expect(html).to.contain(`<p>world</p>`);
       });
 
       it(`should make included mixins available`, function() {
         const html = renderFixture(`include-with-mixin`);
-        assert(html.includes(`<div class="foo">`));
-        assert(html.includes(`<div class="hello">insert me</div>`));
+        expect(html).to.contain(`<div class="foo">`);
+        expect(html).to.contain(`<div class="hello">insert me</div>`);
       });
 
       it(`should insert extended files`, function() {
         const html = renderFixture(`extends`);
-        assert(html.includes(`<div class="foo">`));
-        assert(html.includes(`capybara`));
-        assert(html.includes(`default content`));
+        expect(html).to.contain(`<div class="foo">`);
+        expect(html).to.contain(`capybara`);
+        expect(html).to.contain(`default content`);
       });
     });
 
     describe(`attributes`, function() {
       it(`should add arbitrary attributes`, function() {
         const html = renderFixture(`attributes`);
-        assert(html.includes(`required`));
-        assert(!html.includes(`something`) || html.includes(`something="false"`));
+        expect(html).to.contain(`required`);
+        expect(!html.includes(`something`) || html.includes(`something="false"`)).to.be.ok();
       });
 
       it(`should add class attributes in array notation`, function() {
         let html = renderFixture(`attributes`);
-        assert(html.includes(`1 2`));
+        expect(html).to.contain(`1 2`);
         html = renderFixture(`attributes`, {variable: `meow`});
-        assert(html.includes(`1 2 meow`));
+        expect(html).to.contain(`1 2 meow`);
       });
 
       it(`should add class attributes in object notation`, function() {
         let html = renderFixture(`attributes`);
-        assert(html.includes(`obj1`));
-        assert(!html.includes(`obj2`));
+        expect(html).to.contain(`obj1`);
+        expect(html).not.to.contain(`obj2`);
 
         html = renderFixture(`attributes`, {variable: `doge`});
-        assert(html.includes(`obj1`));
-        assert(html.includes(`obj2`));
+        expect(html).to.contain(`obj1`);
+        expect(html).to.contain(`obj2`);
       });
 
       it(`should combine class attributes in different notations gracefully`, function() {
         let html = renderFixture(`attributes`);
-        assert(html.includes(`mixed`));
-        assert(html.includes(`mixedArray1`));
-        assert(!html.includes(`mixedObj1`));
+        expect(html).to.contain(`mixed`);
+        expect(html).to.contain(`mixedArray1`);
+        expect(html).not.to.contain(`mixedObj1`);
 
         html = renderFixture(`attributes`, {var2: `doge`});
-        assert(html.includes(`mixed`));
-        assert(html.includes(`mixedArray1`));
-        assert(html.includes(`mixedObj1`));
-        assert(html.includes(`doge`));
+        expect(html).to.contain(`mixed`);
+        expect(html).to.contain(`mixedArray1`);
+        expect(html).to.contain(`mixedObj1`);
+        expect(html).to.contain(`doge`);
       });
 
       it(`should render data attributes`, function() {
         const html = renderFixture(`attributes`, {variable: `capybara`});
-        assert(html.includes(`data-foo-id="42"`));
-        assert(html.includes(`data-var="capybara"`));
+        expect(html).to.contain(`data-foo-id="42"`);
+        expect(html).to.contain(`data-var="capybara"`);
       });
 
       it(`should convert attributes to correct property names`, function() {
         const html = renderFixture(`attributes`);
-        assert(html.includes(`autocomplete="on"`));
-        assert(html.includes(`tabindex="5"`));
-        assert(html.includes(`for="special-attr"`));
+        expect(html).to.contain(`autocomplete="on"`);
+        expect(html).to.contain(`tabindex="5"`);
+        expect(html).to.contain(`for="special-attr"`);
       });
     });
 
     describe(`case statements`, function() {
       it(`should not execute any cases when none match`, function() {
         const html = renderFixture(`case`);
-        assert(!html.includes(`foo`));
-        assert(!html.includes(`bar`));
+        expect(html).not.to.contain(`foo`);
+        expect(html).not.to.contain(`bar`);
       });
 
       it(`should execute default when no others match`, function() {
         const html = renderFixture(`case`);
-        assert(html.includes(`llama`));
+        expect(html).to.contain(`llama`);
       });
 
       it(`should execute only one match`, function() {
         const html = renderFixture(`case`, {variable: 1});
-        assert(html.includes(`span`));
-        assert(!html.includes(`input`));
-        assert(!html.includes(`textarea`));
+        expect(html).to.contain(`span`);
+        expect(html).not.to.contain(`input`);
+        expect(html).not.to.contain(`textarea`);
       });
 
       it(`should fall through from the first case in a chain`, function() {
         const html = renderFixture(`case`, {variable2: `d`});
-        assert(html.includes(`bar`));
-        assert(!html.includes(`foo`));
+        expect(html).to.contain(`bar`);
+        expect(html).not.to.contain(`foo`);
       });
 
       it(`should fall through from the middle case in a chain`, function() {
         const html = renderFixture(`case`, {variable2: `e`});
-        assert(html.includes(`bar`));
-        assert(!html.includes(`foo`));
+        expect(html).to.contain(`bar`);
+        expect(html).not.to.contain(`foo`);
       });
 
       it(`should fall through from the last case in a chain`, function() {
         const html = renderFixture(`case`, {variable2: `f`});
-        assert(html.includes(`bar`));
-        assert(!html.includes(`foo`));
+        expect(html).to.contain(`bar`);
+        expect(html).not.to.contain(`foo`);
       });
     });
 
@@ -314,15 +314,15 @@ for (let vdom of VDOM_LIBS) {
       });
 
       it(`should output inline buffered code`, function() {
-        assert(html.includes(`<div class="inline-script"><div class="raw-inline">within another div`));
+        expect(html).to.contain(`<div class="inline-script"><div class="raw-inline">within another div`);
       });
 
       it(`should output standalone buffered code`, function() {
-        assert(html.includes(`<div class="raw-buffered">raw so raw`));
+        expect(html).to.contain(`<div class="raw-buffered">raw so raw`);
       });
 
       it(`should not output unbuffered code`, function() {
-        assert(!html.includes(`should not be output`));
+        expect(html).not.to.contain(`should not be output`);
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -50,60 +50,33 @@ function fixtureToHTML(fixtureName, locals, options) {
 
 describe(`configuration`, function() {
   it(`should throw when an invalid vdom config is supplied`, function() {
-    let threw = false;
-    try {
-      render(fixture(`simple`), {
-        filename: fixtureFilename(`simple`),
-        vdom: `foobar`,
-      });
-    } catch (err) {
-      threw = true;
-      assert(err.message === `No virtual-jade config found for vdom type: foobar`);
-    } finally {
-      assert(threw, `an error should be thrown`);
-    }
+    expect(render).withArgs(fixture(`simple`), {
+      filename: fixtureFilename(`simple`),
+      vdom: `foobar`,
+    }).to.throwException(`No virtual-jade config found for vdom type: foobar`);
   });
 
   it(`should throw a parser error with filename and line number when rendering a broken template`, function() {
     const file = `break-parser`;
     const filename = fixtureFilename(file);
-    const compile = function() {
-      render(fixture(file), {filename});
-    };
-    let threw = false;
 
-    try {
-      compile();
-    } catch (err) {
-      threw = true;
+    expect(render).withArgs(fixture(file), {filename}).to.throwException(function(err) {
       const filenameAndLineNo = new RegExp(filename.replace(`/`, `\/`) + `:2`);
-      assert(err.path === filename, `err.path should be the full path to the jade file`);
-      assert(err.message.match(filenameAndLineNo), `the error message should contain the full path and line number`);
-      assert(err.message.match(/Unexpected identifier/), `the error message should contain the error type`);
-    } finally {
-      assert(threw, `an error should be thrown`);
-    }
+      expect(err.path).to.be(filename);
+      expect(err.message).to.match(filenameAndLineNo);
+      expect(err.message).to.match(/Unexpected identifier/);
+    });
   });
 
   it(`should throw a compiler error with filename and line number when rendering a broken template`, function() {
     const file = `break-compiler`;
     const filename = fixtureFilename(file);
-    const compile = function() {
-      render(fixture(file), {filename});
-    };
-    let threw = false;
-
-    try {
-      compile();
-    } catch (err) {
-      threw = true;
+    expect(render).withArgs(fixture(file), {filename}).to.throwException(function(err) {
       const filenameAndLineNo = new RegExp(filename.replace(`/`, `\/`) + `:2`);
-      assert(err.path === filename, `err.path (` + err.path + `) should be the full path to the jade file`);
-      assert(err.message.match(filenameAndLineNo), `the error message should contain the full path and line number`);
-      assert(err.message.match(/You can only have one top-level tag!/), `the error message should contain the error type`);
-    } finally {
-      assert(threw, `an error should be thrown`);
-    }
+      expect(err.path).to.be(filename);
+      expect(err.message).to.match(filenameAndLineNo);
+      expect(err.message).to.match(/You can only have one top-level tag!/);
+    });
   });
 
   it(`should render a template without options`, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@
 
 const assert = require(`assert`);
 const debug = require(`debug`)(`test`);
+const expect = require(`expect.js`);
 const fs = require(`fs`);
 const jsdom = require(`mocha-jsdom`);
 const parse5 = require(`parse5-utils`);
@@ -173,12 +174,12 @@ for (let vdom of VDOM_LIBS) {
     describe(`iteration`, function() {
       it(`should run "each" loops correctly`, function() {
         const html = renderFixture(`each-expression`, {values: [`foo`, `bar`]});
-        assert(html.includes(`<li>foo</li><li>bar</li>`));
+        expect(html).to.contain(`<li>foo</li><li>bar</li>`);
       });
 
       it(`should run "while" loops correctly`, function() {
         const html = renderFixture(`while`);
-        assert(html.match(/<div class=\"item\">/g).length === 5);
+        expect(html.match(/<div class=\"item\">/g)).to.have.length(5);
       });
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,8 @@ function fixtureToHTML(fixtureName, locals, options) {
   const root = fn.call({class: `asdf`}, locals);
   const toHTML = snabb ? snabbdomToHTML : vdomToHTML;
   const html = toHTML(root);
+  debug(html);
+
   parse5.parse(html, true);
   return html;
 }
@@ -121,7 +123,7 @@ const VDOM_LIBS = [
 
 for (let vdom of VDOM_LIBS) {
   const renderFixture = function(fixtureName, locals) {
-    return fixtureToHTML(fixtureName, locals, {vdom});
+    return fixtureToHTML(fixtureName, locals, {vdom, pretty: true});
   };
 
   describe(`rendering with ${vdom}`, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -147,11 +147,6 @@ for (let vdom of VDOM_LIBS) {
       assert(lines[lines.length - 1].trim() === `}`);
     });
 
-    it(`should run while loops correctly`, function() {
-      const html = renderFixture(`while`);
-      assert(html.match(/<div class=\"item\">/g).length === 5);
-    });
-
     it(`should insert dynamic tag names`, function() {
       let html = renderFixture(`dynamic-tag`, {myTag: `input`});
       assert(html.includes(`<input class="llamas">`));
@@ -168,6 +163,18 @@ for (let vdom of VDOM_LIBS) {
       const html = renderFixture(`class`);
       assert(html.includes(`div class="foo"`));
       assert(html.includes(`div class="baz llamas"`));
+    });
+
+    describe(`iteration`, function() {
+      it(`should run "each" loops correctly`, function() {
+        const html = renderFixture(`each-expression`, {values: ['foo', 'bar']});
+        assert(html.includes(`<li>foo</li><li>bar</li>`));
+      });
+
+      it(`should run "while" loops correctly`, function() {
+        const html = renderFixture(`while`);
+        assert(html.match(/<div class=\"item\">/g).length === 5);
+      });
     });
 
     describe(`multiple files`, function() {


### PR DESCRIPTION
Looks like `each` only had a compiler unit test, so this wasn't caught. Now it has an integration test.

Basic problem of snabb being less forgiving than virtual-dom about children as flattened vs nested arrays. This fix includes a minor refactoring of `visitBlock` to make the generated code always return arrays, and `visitEach` to flatten as it goes.

+ a lot of test style cleanup, move to `expect.js`