### PR TITLE
use reduce instead of for-loop for generated 'each' code

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -455,14 +455,9 @@ Compiler.prototype.visitCase = function(code) {
  */
 
 Compiler.prototype.visitEach = function(code) {
-  return `(function(__list) {
-    var __each_nodes = [];
-    for (var ${code.key} = 0; ${code.key} < __list.length; ${code.key}++) {
-      var ${code.val} = __list[${code.key}];
-      __each_nodes = __each_nodes.concat(${this.visitBlock(code.block)});
-    }
-    return __each_nodes;
-  })(${code.obj})`;
+  return `(${code.obj}).reduce(function(__each_nodes, ${code.val}, ${code.key}) {
+    return __each_nodes.concat(${this.visitBlock(code.block)});
+  }, [])`;
 };
 
 /**


### PR DESCRIPTION
most importantly to close over value/index at each iteration.
will have to think of a way to unit-test this appropriately.