### PR TITLE
fix for null output from buffered code blocks

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -166,7 +166,7 @@ Compiler.prototype.visitTag = function(tag) {
   if (tag.code) {
     // NOTE: should we cast this to a String?
     // might be interesting to include another virtual-dom...
-    buf += `, [(${tag.code.val})]`;
+    buf += `, [(${tag.code.val} || '')]`;
   } else {
     let buf2 = this.visitBlock(tag.block);
     if (buf2) {

--- a/test/fixtures/code.jade
+++ b/test/fixtures/code.jade
@@ -11,3 +11,5 @@ div
   - h('.unbuffered', 'should not be output')
   .empty-code
     -
+
+  .buffered-null= null


### PR DESCRIPTION
snabbdom is not as loosey-goosey about getting null children as virtual-dom is, so `.foo= null` currently blows up at patch time rather than treating it as an empty text node