### PR TITLE
Fix spacing between adjacent text nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ each val in allItems.slice(startIdx, endIdx)
   = props.itemRenderer(val)
 ```
 
+## Development notes
+- Install deps: `npm install`
+- Run tests: `npm test`
+- Run linter: `npm run lint`
+- Generate coverage report: `npm run test-cov`
+- Run all the verifications together: `npm run test-ci`
+- Run tests with verbose debugging output (compiled functions as well as rendered HTML): `DEBUG=test npm test`
+
 [travis-image]: https://img.shields.io/travis/tdumitrescu/virtual-jade/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/tdumitrescu/virtual-jade
 [coveralls-image]: https://img.shields.io/coveralls/tdumitrescu/virtual-jade.svg?style=flat-square

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -403,10 +403,8 @@ Compiler.prototype.visitBlock = function(block) {
       case `Text`: {
         // contiguous text nodes need to be rendered with whitespace in between
         const prefix = i > 0 && nodes[i - 1].type === `Text` ? ` ` : ``;
-        curNodeBuf += this.visitText(node, prefix);
-        if (curNodeBuf) {
-          buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
-        }
+        curNodeBuf = this.visitText(node, prefix);
+        buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
         break;
       }
       default: {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -400,7 +400,7 @@ Compiler.prototype.visitBlock = function(block) {
         curNodeBuf = this.visitEach(node);
         buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
         break;
-      case `Text`:
+      case `Text`: {
         // contiguous text nodes need to be rendered with whitespace in between
         const prefix = i > 0 && nodes[i - 1].type === `Text` ? ` ` : ``;
         curNodeBuf += this.visitText(node, prefix);
@@ -408,6 +408,7 @@ Compiler.prototype.visitBlock = function(block) {
           buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
         }
         break;
+      }
       default: {
         curNodeBuf = this.visit(node);
         if (curNodeBuf) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -132,8 +132,8 @@ Compiler.prototype.visitBlockComment = function(node) {
  * Create basic text nodes.
  */
 
-Compiler.prototype.visitText = function(node) {
-  return JSON.stringify(node.val)
+Compiler.prototype.visitText = function(node, prefix=``) {
+  return JSON.stringify(prefix + node.val)
     .replace(/#\{(.+?)\}/g, `" + ($1) + "`);
 };
 
@@ -399,6 +399,14 @@ Compiler.prototype.visitBlock = function(block) {
       case `Each`:
         curNodeBuf = this.visitEach(node);
         buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
+        break;
+      case `Text`:
+        // contiguous text nodes need to be rendered with whitespace in between
+        const prefix = i > 0 && nodes[i - 1].type === `Text` ? ` ` : ``;
+        curNodeBuf += this.visitText(node, prefix);
+        if (curNodeBuf) {
+          buf += `__jade_nodes = __jade_nodes.concat(${curNodeBuf});`;
+        }
         break;
       default: {
         curNodeBuf = this.visit(node);

--- a/test/fixtures/text.jade
+++ b/test/fixtures/text.jade
@@ -1,12 +1,19 @@
 .text
   .inline-in-tag Inlined within tag
+
   .piped
     | Hello
     | world
+
   .tags-whitespace
     | You put the em
     em pha
     | sis on the wrong syl
     em la
     | ble.
+
   .tag-interpolation Sweet #[blink flashy] tags
+
+  .block-in-tag.
+    Arbitrary text
+    and more arbitrary text

--- a/test/fixtures/text.jade
+++ b/test/fixtures/text.jade
@@ -3,3 +3,9 @@
   .piped
     | Hello
     | world
+  .tags-whitespace
+    | You put the em
+    em pha
+    | sis on the wrong syl
+    em la
+    | ble.

--- a/test/fixtures/text.jade
+++ b/test/fixtures/text.jade
@@ -9,3 +9,4 @@
     | sis on the wrong syl
     em la
     | ble.
+  .tag-interpolation Sweet #[blink flashy] tags

--- a/test/fixtures/text.jade
+++ b/test/fixtures/text.jade
@@ -1,0 +1,5 @@
+.text
+  .inline-in-tag Inlined within tag
+  .piped
+    | Hello
+    | world

--- a/test/test.js
+++ b/test/test.js
@@ -407,10 +407,14 @@ describe(`rendering`, function() {
 });
 
 describe(`snabbdom-specific rendering`, function() {
-  const html = fixtureToHTML(`snabb`, {}, {
-    vdom: `snabbdom`,
-    snabbArgs: true,
-    pretty: true,
+  let html;
+
+  beforeEach(function() {
+    html = fixtureToHTML(`snabb`, {}, {
+      vdom: `snabbdom`,
+      snabbArgs: true,
+      pretty: true,
+    });
   });
 
   it(`renders plain objects`, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -397,6 +397,10 @@ describe(`rendering`, function() {
         it(`renders inlined text`, function() {
           expect(html).to.contain(`<div class="inline-in-tag">Inlined within tag</div>`);
         });
+
+        it(`renders piped text with spaces between lines`, function() {
+          expect(html).to.contain(`<div class="piped">Hello world</div>`);
+        });
       });
     });
   }

--- a/test/test.js
+++ b/test/test.js
@@ -386,6 +386,18 @@ describe(`rendering`, function() {
           expect(htmlMixin).to.be(html$Mixin);
         });
       });
+
+      describe(`plain text`, function() {
+        let html;
+
+        beforeEach(function() {
+          html = renderFixture(`text`);
+        });
+
+        it(`renders inlined text`, function() {
+          expect(html).to.contain(`<div class="inline-in-tag">Inlined within tag</div>`);
+        });
+      });
     });
   }
 });

--- a/test/test.js
+++ b/test/test.js
@@ -409,6 +409,10 @@ describe(`rendering`, function() {
         it(`supports tag interpolation syntax`, function() {
           expect(html).to.contain(`<div class="tag-interpolation">Sweet <blink>flashy</blink> tags</div>`);
         });
+
+        it(`supports block-in-tag trailing dot syntax`, function() {
+          expect(html).to.contain(`<div class="block-in-tag">Arbitrary text and more arbitrary text</div>`);
+        });
       });
     });
   }

--- a/test/test.js
+++ b/test/test.js
@@ -401,6 +401,10 @@ describe(`rendering`, function() {
         it(`renders piped text with spaces between lines`, function() {
           expect(html).to.contain(`<div class="piped">Hello world</div>`);
         });
+
+        it(`does not insert extraneous whitespace between tags`, function() {
+          expect(html).to.contain(`<div class="tags-whitespace">You put the em<em>pha</em>sis on the wrong syl<em>la</em>ble.</div>`);
+        });
       });
     });
   }

--- a/test/test.js
+++ b/test/test.js
@@ -405,6 +405,10 @@ describe(`rendering`, function() {
         it(`does not insert extraneous whitespace between tags`, function() {
           expect(html).to.contain(`<div class="tags-whitespace">You put the em<em>pha</em>sis on the wrong syl<em>la</em>ble.</div>`);
         });
+
+        it(`supports tag interpolation syntax`, function() {
+          expect(html).to.contain(`<div class="tag-interpolation">Sweet <blink>flashy</blink> tags</div>`);
+        });
       });
     });
   }


### PR DESCRIPTION
So that you don't have to do stuff like
```jade
div
  | Hello
  |  world
```
to render "Hello world". This should match current pug behavior according to https://pugjs.org/language/plain-text.html. Added test cases for a bunch of the other cases on that page, though a few syntaxes there are not supported in the old version of the jade parser we're still using here.