### PR TITLE
JSON.stringify object attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 node_js:
-  - "6.9"
-  - "8"
   - "10"
+  - "12"
 language: node_js
 sudo: false
 script: "npm run test-ci"

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -51,6 +51,7 @@ Compiler.prototype.compile = function() {
   let js = ``;
 
   this.hasObjAttrs = false;
+  this.hasAttrsProp = false;
   this.mixins = [];
 
   for (const node of this.node.nodes) {
@@ -91,6 +92,22 @@ Compiler.prototype.compile = function() {
       var __vjadeObjToAttrs = function(o) {
         return Object.keys(o).map(function(k) { return o[k] ? k : false});
       };
+      ${js}
+    `;
+  }
+
+  if (this.hasAttrsProp) {
+    js = `
+      var __vjadeStringifyAttrsIfObj = function(attrs) {
+        if (typeof attrs !== 'object') return attrs;
+        const copy = Object.assign({}, attrs);
+        for (const k in attrs) {
+          if (typeof attrs[k] === 'object') {
+            copy[k] = JSON.stringify(attrs[k]);
+          }
+        }
+        return copy;
+      }
       ${js}
     `;
   }
@@ -268,6 +285,9 @@ Compiler.prototype.visitAttributes = function(attrs) {
         }
       } else if (attr.name === `id` && attr.val[0] === `'`) {
         id = attr.val;
+      } else if (attr.name === `attrs`) {
+        this.hasAttrsProp = true;
+        props[attr.name] = `__vjadeStringifyAttrsIfObj(${attr.val})`;
       } else {
         props[attr.name] = attr.val;
       }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -6,6 +6,7 @@ const OVERRIDABLE_CONFIG_OPTIONS = [
   `marshalDataset`,
   `propsWrapper`,
   `rawProps`,
+  `serializeAttrsObjects`,
 ];
 
 /**
@@ -101,7 +102,7 @@ Compiler.prototype.compile = function() {
       var __vjadeStringifyAttrsIfObj = function(attrs) {
         if (typeof attrs !== 'object') return attrs;
         const copy = Object.assign({}, attrs);
-        for (const k in attrs) {
+        for (const [k, v] of Object.entries(attrs)) {
           if (typeof attrs[k] === 'object') {
             copy[k] = JSON.stringify(attrs[k]);
           }
@@ -285,7 +286,10 @@ Compiler.prototype.visitAttributes = function(attrs) {
         }
       } else if (attr.name === `id` && attr.val[0] === `'`) {
         id = attr.val;
-      } else if (attr.name === `attrs`) {
+      } else if (this.serializeAttrsObjects && attr.name === `attrs`) {
+        // special case for snabbdom's 'attrs' object notation for specifying HTML attributes
+        // since attributes are always strings, automatically JSON-serialize any object values
+        // e.g.: in attrs={foo: {bar: 'baz'}} the {bar: 'baz'} should be auto-serialized
         this.hasAttrsProp = true;
         props[attr.name] = `__vjadeStringifyAttrsIfObj(${attr.val})`;
       } else {

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ const VDOM_CONFIG = {
     rawProps: true, // don't translate Jade attrs to HTML props
     marshalDataset: false,
     runtime: `var h = require('snabbdom/h');`,
+    serializeAttrsObjects: true,
   },
 
   'virtual-dom': {

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -47,6 +47,11 @@ describe(`Compiler`, function() {
     parse5.parse(html, true);
   });
 
+  it(`optionally wraps attributes in a stringify call`, function() {
+    const js = testCompilation(`attributes`, {rawProps: true});
+    expect(js).to.contain(`__vjadeStringifyAttrsIfObj({obj: {foo: 'bar'}})`);
+  });
+
   it(`compiles attributes`, function() {
     const js = testCompilation(`attributes`);
     expect(js).not.to.match(/\bclass\b/);

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -48,7 +48,7 @@ describe(`Compiler`, function() {
   });
 
   it(`optionally wraps attributes in a stringify call`, function() {
-    const js = testCompilation(`attributes`, {rawProps: true});
+    const js = testCompilation(`attributes`, {rawProps: true, serializeAttrsObjects: true});
     expect(js).to.contain(`__vjadeStringifyAttrsIfObj({obj: {foo: 'bar'}})`);
   });
 

--- a/test/fixtures/attributes.jade
+++ b/test/fixtures/attributes.jade
@@ -4,6 +4,7 @@ div#id.class1(
   something=false
   data-foo-id=42
   data-var=variable
+  attrs={obj: {foo: 'bar'}}
 )
   div(class=[foo, bar] class=baz)
   div(class={obj1: true, obj2: variable === 'doge'})

--- a/test/fixtures/snabb.jade
+++ b/test/fixtures/snabb.jade
@@ -1,7 +1,7 @@
 //- snabbdom-specific API
 .jade-class.foo(
   class={'obj-class': true}
-  attrs={bar: 'baz'}
+  attrs={bar: 'baz', obj: {hello: 'world'}}
   props={id: 'xxx'}
 )
   .single-class(attrs={yyy: 'zzz'})

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ const parse5 = require(`parse5-utils`);
 const path = require(`path`);
 const vdomToHTML = require(`vdom-to-html`);
 const snabbdomToHTML = require(`snabbdom-to-html`);
+const escape = require(`escape-html`);
 
 const render = require(`..`);
 
@@ -435,6 +436,10 @@ describe(`snabbdom-specific rendering`, function() {
 
   it(`renders arbitrary attributes`, function() {
     expect(html).to.contain(`bar="baz"`);
+  });
+
+  it(`serializes object attributes`, function() {
+    expect(html).to.contain(`obj="${escape(JSON.stringify({hello: `world`}))}"`);
   });
 
   it(`renders properties`, function() {

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,6 @@ const parse5 = require(`parse5-utils`);
 const path = require(`path`);
 const vdomToHTML = require(`vdom-to-html`);
 const snabbdomToHTML = require(`snabbdom-to-html`);
-const escape = require(`escape-html`);
 
 const render = require(`..`);
 
@@ -439,7 +438,7 @@ describe(`snabbdom-specific rendering`, function() {
   });
 
   it(`serializes object attributes`, function() {
-    expect(html).to.contain(`obj="${escape(JSON.stringify({hello: `world`}))}"`);
+    expect(html).to.contain(`obj="{&quot;hello&quot;:&quot;world&quot;}"`);
   });
 
   it(`renders properties`, function() {


### PR DESCRIPTION
When passing down attributes to an element, it is no use to convert a javascript object into `[object Object]`. This PR adds a wrapper which stringifies all objects nested under the `attrs` key to make passing simple serializable objects seamless to the developer.

Why the `attrs` key only? this is how the wrapper key that snabbdom uses for attributes and I wanted to limit the scope of these conversions.