### PR TITLE
don't JSONify an object with toString()

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -103,7 +103,12 @@ Compiler.prototype.compile = function() {
         if (typeof attrs !== 'object') return attrs;
         const copy = {};
         for (const [k, v] of Object.entries(attrs)) {
-          copy[k] = typeof attrs[k] === 'object' ? JSON.stringify(v) : v;
+          if (typeof v === 'object') {
+            const toStringDefined = v.hasOwnProperty('toString') && typeof v.toString === 'function';
+            copy[k] = toStringDefined ? v : JSON.stringify(v);
+          } else {
+            copy[k] = v;
+          }
         }
         return copy;
       }

--- a/test/fixtures/snabb.jade
+++ b/test/fixtures/snabb.jade
@@ -1,7 +1,7 @@
 //- snabbdom-specific API
 .jade-class.foo(
   class={'obj-class': true}
-  attrs={bar: 'baz', obj: {hello: 'world'}}
+  attrs={bar: 'baz', obj: {hello: 'world'}, stringable: {toString() {return 'asAString'}}}
   props={id: 'xxx'}
 )
   .single-class(attrs={yyy: 'zzz'})

--- a/test/test.js
+++ b/test/test.js
@@ -441,6 +441,10 @@ describe(`snabbdom-specific rendering`, function() {
     expect(html).to.contain(`obj="{&quot;hello&quot;:&quot;world&quot;}"`);
   });
 
+  it(`doesn't serialize object attributes that define toString`, function() {
+    expect(html).to.contain(`stringable="asAString"`);
+  });
+
   it(`renders properties`, function() {
     expect(html).to.contain(`id="xxx"`);
   });


### PR DESCRIPTION
In some places, we rely on the toString behavior of objects passed as attrs. Check first for the function and if it's not defined, call JSON.stringify. This will break for inheritance hierarchies where toString is defined one or more levels above the instance but should work for our use cases.